### PR TITLE
feat: 관리자 유저 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/firstskin/firstskin/admin/api/controller/AdminMemberController.java
+++ b/src/main/java/firstskin/firstskin/admin/api/controller/AdminMemberController.java
@@ -1,0 +1,23 @@
+package firstskin.firstskin.admin.api.controller;
+
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.admin.service.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/members")
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping
+    public Page<MemberResponse> getMembers(Pageable pageable) {
+        return adminMemberService.getMembers(pageable);
+    }
+}

--- a/src/main/java/firstskin/firstskin/admin/api/controller/AdminMemberController.java
+++ b/src/main/java/firstskin/firstskin/admin/api/controller/AdminMemberController.java
@@ -5,13 +5,11 @@ import firstskin.firstskin.admin.service.AdminMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/members")
+@RequestMapping("/admin/users")
 public class AdminMemberController {
 
     private final AdminMemberService adminMemberService;
@@ -19,5 +17,10 @@ public class AdminMemberController {
     @GetMapping
     public Page<MemberResponse> getMembers(Pageable pageable) {
         return adminMemberService.getMembers(pageable);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public void inactiveMember(@PathVariable Long memberId) {
+        adminMemberService.inactiveMember(memberId);
     }
 }

--- a/src/main/java/firstskin/firstskin/admin/api/dto/response/MemberResponse.java
+++ b/src/main/java/firstskin/firstskin/admin/api/dto/response/MemberResponse.java
@@ -1,0 +1,29 @@
+package firstskin.firstskin.admin.api.dto.response;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class MemberResponse {
+
+    private final String userId;
+    private final String profile;
+    private final LocalDateTime createdDate;
+    private final String nickname;
+    private final String type;
+    private final String trouble;
+    private final String personalColor;
+
+    public MemberResponse(String userId, String profile, LocalDateTime createdDate, String nickname, String type, String trouble, String personalColor) {
+        this.userId = userId;
+        this.profile = profile;
+        this.createdDate = createdDate;
+        this.nickname = nickname;
+        this.type = type;
+        this.trouble = trouble;
+        this.personalColor = personalColor;
+    }
+}

--- a/src/main/java/firstskin/firstskin/admin/api/dto/response/MemberResponse.java
+++ b/src/main/java/firstskin/firstskin/admin/api/dto/response/MemberResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @ToString
 public class MemberResponse {
 
+    private final Long memberId;
     private final String userId;
     private final String profile;
     private final LocalDateTime createdDate;
@@ -17,7 +18,8 @@ public class MemberResponse {
     private final String trouble;
     private final String personalColor;
 
-    public MemberResponse(String userId, String profile, LocalDateTime createdDate, String nickname, String type, String trouble, String personalColor) {
+    public MemberResponse(Long memberId, String userId, String profile, LocalDateTime createdDate, String nickname, String type, String trouble, String personalColor) {
+        this.memberId = memberId;
         this.userId = userId;
         this.profile = profile;
         this.createdDate = createdDate;

--- a/src/main/java/firstskin/firstskin/admin/service/AdminMemberService.java
+++ b/src/main/java/firstskin/firstskin/admin/service/AdminMemberService.java
@@ -1,11 +1,13 @@
 package firstskin.firstskin.admin.service;
 
 import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +17,15 @@ public class AdminMemberService {
 
     public Page<MemberResponse> getMembers(Pageable pageable) {
         return memberRepository.getMembers(pageable);
+    }
+
+    @Transactional
+    public void inactiveMember(Long memberId) {
+        Member findMember = memberRepository
+                .findById(memberId)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+
+        findMember.delete();
     }
 }

--- a/src/main/java/firstskin/firstskin/admin/service/AdminMemberService.java
+++ b/src/main/java/firstskin/firstskin/admin/service/AdminMemberService.java
@@ -1,0 +1,19 @@
+package firstskin.firstskin.admin.service;
+
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Page<MemberResponse> getMembers(Pageable pageable) {
+        return memberRepository.getMembers(pageable);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/config/QueryDslConfig.java
+++ b/src/main/java/firstskin/firstskin/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package firstskin.firstskin.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/entity/BaseTimeEntity.java
+++ b/src/main/java/firstskin/firstskin/common/entity/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package firstskin.firstskin.common.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/firstskin/firstskin/common/entity/BaseTimeEntity.java
+++ b/src/main/java/firstskin/firstskin/common/entity/BaseTimeEntity.java
@@ -1,12 +1,15 @@
 package firstskin.firstskin.common.entity;
 
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/firstskin/firstskin/dianosis/DiagnosisRepository.java
+++ b/src/main/java/firstskin/firstskin/dianosis/DiagnosisRepository.java
@@ -1,0 +1,7 @@
+package firstskin.firstskin.dianosis;
+
+import firstskin.firstskin.dianosis.domain.Diagnosis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiagnosisRepository extends JpaRepository<Diagnosis, Long> {
+}

--- a/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
+++ b/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
@@ -4,8 +4,12 @@ import firstskin.firstskin.common.entity.BaseTimeEntity;
 import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.skin.Skin;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Diagnosis extends BaseTimeEntity {
 
     @Id
@@ -23,4 +27,11 @@ public class Diagnosis extends BaseTimeEntity {
 
     @Column(name = "skin_picture_url")
     private String skinPictureUrl;
+
+    @Builder
+    public Diagnosis(Member member, Skin skin, String skinPictureUrl) {
+        this.member = member;
+        this.skin = skin;
+        this.skinPictureUrl = skinPictureUrl;
+    }
 }

--- a/src/main/java/firstskin/firstskin/member/domain/Member.java
+++ b/src/main/java/firstskin/firstskin/member/domain/Member.java
@@ -2,7 +2,8 @@ package firstskin.firstskin.member.domain;
 
 import firstskin.firstskin.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -35,5 +36,10 @@ public class Member extends BaseTimeEntity {
         this.profileUrl = profileImageUrl;
         this.userId = userId;
         this.nickname = nickname;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.activated = true;
     }
 }

--- a/src/main/java/firstskin/firstskin/member/domain/Member.java
+++ b/src/main/java/firstskin/firstskin/member/domain/Member.java
@@ -38,6 +38,10 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
+    public void delete() {
+        this.activated = false;
+    }
+
     @PrePersist
     public void prePersist() {
         this.activated = true;

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepository.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepository.java
@@ -1,9 +1,8 @@
 package firstskin.firstskin.member.repository;
 
-import firstskin.firstskin.category.domain.Category;
 import firstskin.firstskin.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Member findByUserId(String userId);
 }

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package firstskin.firstskin.member.repository;
+
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberRepositoryCustom {
+
+    Page<MemberResponse> getMembers(Pageable pageable);
+}

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
@@ -27,6 +27,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         List<MemberResponse> fetch = queryFactory
                 .select(Projections.constructor(
                         MemberResponse.class,
+                        member.memberId.as("memberId"),
                         member.userId.as("userId"),
                         member.profileUrl.as("profile"),
                         member.createdDate.as("createdDate"),

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,60 @@
+package firstskin.firstskin.member.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.skin.Kind;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static firstskin.firstskin.dianosis.domain.QDiagnosis.diagnosis;
+import static firstskin.firstskin.member.domain.QMember.member;
+import static firstskin.firstskin.skin.QSkin.skin;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MemberResponse> getMembers(Pageable pageable) {
+        List<MemberResponse> fetch = queryFactory
+                .select(Projections.constructor(
+                        MemberResponse.class,
+                        member.userId.as("userId"),
+                        member.profileUrl.as("profile"),
+                        member.createdDate.as("createdDate"),
+                        member.nickname.as("nickname"),
+                        selectKindOfSkin(Kind.TYPE),
+                        selectKindOfSkin(Kind.TROUBLE),
+                        selectKindOfSkin(Kind.PERSONAL_COLOR)
+                ))
+                .from(member)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(member.count())
+                .from(member)
+                .fetchOne();
+
+        return new PageImpl<>(fetch, pageable, count == null ? 0 : count);
+    }
+
+    private static JPQLQuery<String> selectKindOfSkin(Kind type) {
+        return JPAExpressions
+                .select(skin.result)
+                .from(diagnosis)
+                .join(diagnosis.skin, skin)
+                .where(diagnosis.member.eq(member).and(skin.kind.eq(type)))
+                .orderBy(diagnosis.createdDate.desc())
+                .limit(1);
+    }
+}

--- a/src/main/java/firstskin/firstskin/skin/Skin.java
+++ b/src/main/java/firstskin/firstskin/skin/Skin.java
@@ -16,4 +16,9 @@ public class Skin {
     private Kind kind;
 
     private String result;
+
+    public Skin(Kind kind, String result) {
+        this.kind = kind;
+        this.result = result;
+    }
 }

--- a/src/main/java/firstskin/firstskin/skin/repository/SkinRepository.java
+++ b/src/main/java/firstskin/firstskin/skin/repository/SkinRepository.java
@@ -1,0 +1,7 @@
+package firstskin.firstskin.skin.repository;
+
+import firstskin.firstskin.skin.Skin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SkinRepository extends JpaRepository<Skin, Long> {
+}

--- a/src/main/java/firstskin/firstskin/user/service/MemberService.java
+++ b/src/main/java/firstskin/firstskin/user/service/MemberService.java
@@ -2,16 +2,13 @@ package firstskin.firstskin.user.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import firstskin.firstskin.category.domain.Category;
 import firstskin.firstskin.member.domain.Member;
-import firstskin.firstskin.member.domain.Role;
 import firstskin.firstskin.member.repository.MemberRepository;
 import firstskin.firstskin.model.KakaoProfile;
 import firstskin.firstskin.model.OauthToken;
 import firstskin.firstskin.user.api.dto.MemberDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -25,8 +22,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static firstskin.firstskin.member.domain.Role.ROLE_USER;
 
 @Service
 public class MemberService {

--- a/src/test/java/firstskin/firstskin/admin/service/AdminMemberServiceTest.java
+++ b/src/test/java/firstskin/firstskin/admin/service/AdminMemberServiceTest.java
@@ -1,0 +1,107 @@
+package firstskin.firstskin.admin.service;
+
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.dianosis.DiagnosisRepository;
+import firstskin.firstskin.dianosis.domain.Diagnosis;
+import firstskin.firstskin.member.domain.Member;
+import firstskin.firstskin.member.domain.Role;
+import firstskin.firstskin.member.repository.MemberRepository;
+import firstskin.firstskin.skin.Kind;
+import firstskin.firstskin.skin.Skin;
+import firstskin.firstskin.skin.repository.SkinRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AdminMemberServiceTest {
+
+    @Autowired
+    AdminMemberService adminMemberService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    SkinRepository skinRepository;
+
+    @Autowired
+    DiagnosisRepository diagnosisRepository;
+
+    @Test
+    @DisplayName("회원 목록 조회시 퍼스널컬러, 타입, 트러블 결과도 함께 조회된다")
+    public void getMembers() throws Exception{
+        //given
+        Member member1 = new Member(Role.ROLE_USER, "프로필사진1", "아이디1", "닉네임1");
+        Member member2 = new Member(Role.ROLE_USER, "프로필사진2", "아이디2", "닉네임2");
+
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        Skin ps1 = new Skin(Kind.PERSONAL_COLOR, "봄웜");
+        Skin ps2 = new Skin(Kind.PERSONAL_COLOR, "가을쿨");
+
+        Skin ts1 = new Skin(Kind.TYPE, "드라이");
+        Skin ts2 = new Skin(Kind.TYPE, "지성");
+
+        Skin tt1 = new Skin(Kind.TROUBLE, "여드름");
+        Skin tt2 = new Skin(Kind.TROUBLE, "각질");
+
+        skinRepository.save(ps1);
+        skinRepository.save(ps2);
+        skinRepository.save(ts1);
+        skinRepository.save(ts2);
+        skinRepository.save(tt1);
+        skinRepository.save(tt2);
+
+        Diagnosis diagnosis1 = new Diagnosis(member1, ps1, "사진1");
+        Diagnosis diagnosis2 = new Diagnosis(member1, ts1, "사진2");
+        Diagnosis diagnosis3 = new Diagnosis(member1, tt1, "사진2");
+
+        Diagnosis diagnosis4 = new Diagnosis(member2, ps2, "사진2");
+        Diagnosis diagnosis5 = new Diagnosis(member2, ts2, "사진2");
+        Diagnosis diagnosis6 = new Diagnosis(member2, tt2, "사진2");
+
+        diagnosisRepository.save(diagnosis1);
+        diagnosisRepository.save(diagnosis2);
+        diagnosisRepository.save(diagnosis3);
+        diagnosisRepository.save(diagnosis4);
+        diagnosisRepository.save(diagnosis5);
+        diagnosisRepository.save(diagnosis6);
+
+        //when
+        Pageable pageable = Pageable.ofSize(10).withPage(0);
+        Page<MemberResponse> members = adminMemberService.getMembers(pageable);
+
+        //then
+        assertThat(members.getContent().size()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("회원 비활성화시 activated가 false로 변경된다.")
+    public void inactiveMember() throws Exception{
+        //given
+        Member member = new Member(Role.ROLE_USER, "프로필사진1", "아이디1", "닉네임1");
+        memberRepository.save(member);
+
+        //when
+
+        //전
+        Member byUserId1 = memberRepository.findByUserId(member.getUserId());
+        assertThat(byUserId1.isActivated()).isTrue();
+
+        adminMemberService.inactiveMember(member.getMemberId());
+        Member byUserId = memberRepository.findByUserId(member.getUserId());
+
+        //then
+        assertThat(byUserId.isActivated()).isFalse();
+
+
+    }
+}

--- a/src/test/java/firstskin/firstskin/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/firstskin/firstskin/member/repository/MemberRepositoryImplTest.java
@@ -1,0 +1,128 @@
+package firstskin.firstskin.member.repository;
+
+import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.dianosis.DiagnosisRepository;
+import firstskin.firstskin.dianosis.domain.Diagnosis;
+import firstskin.firstskin.member.domain.Member;
+import firstskin.firstskin.member.domain.Role;
+import firstskin.firstskin.skin.Kind;
+import firstskin.firstskin.skin.Skin;
+import firstskin.firstskin.skin.repository.SkinRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@SpringBootTest
+class MemberRepositoryImplTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    DiagnosisRepository diagnosisRepository;
+
+    @Autowired
+    SkinRepository skinRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("회원 목록 조회시 퍼스널컬러, 타입, 트러블 결과도 함께 조회된다")
+    public void getMembers() throws Exception {
+        //given
+        Member member1 = new Member(Role.ROLE_USER, "프로필사진1", "아이디1", "닉네임1");
+        Member member2 = new Member(Role.ROLE_USER, "프로필사진2", "아이디2", "닉네임2");
+
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        Skin ps1 = new Skin(Kind.PERSONAL_COLOR, "봄웜");
+        Skin ps2 = new Skin(Kind.PERSONAL_COLOR, "가을쿨");
+        Skin ps3 = new Skin(Kind.PERSONAL_COLOR, "겨울웜");
+        Skin ps4 = new Skin(Kind.PERSONAL_COLOR, "여름쿨");
+
+        Skin ts1 = new Skin(Kind.TYPE, "드라이");
+        Skin ts2 = new Skin(Kind.TYPE, "지성");
+        Skin ts3 = new Skin(Kind.TYPE, "복합성");
+
+        Skin tt1 = new Skin(Kind.TROUBLE, "여드름");
+        Skin tt2 = new Skin(Kind.TROUBLE, "각질");
+        Skin tt3 = new Skin(Kind.TROUBLE, "건조함");
+
+        skinRepository.save(ps1);
+        skinRepository.save(ps2);
+        skinRepository.save(ps3);
+        skinRepository.save(ps4);
+        skinRepository.save(ts1);
+        skinRepository.save(ts2);
+        skinRepository.save(ts3);
+        skinRepository.save(tt1);
+        skinRepository.save(tt2);
+        skinRepository.save(tt3);
+
+
+        Diagnosis 진단1 = Diagnosis.builder()
+                .member(member1)
+                .skin(ps1)
+                .skinPictureUrl("사진1")
+                .build();
+
+        Diagnosis 진단2 = Diagnosis.builder()
+                .member(member1)
+                .skin(ts2)
+                .skinPictureUrl("사진2")
+                .build();
+
+        Diagnosis 진단3 = Diagnosis.builder()
+                .member(member1)
+                .skin(tt1)
+                .skinPictureUrl("사진3")
+                .build();
+
+        Diagnosis 진단66 = Diagnosis.builder()
+                .member(member2)
+                .skin(tt3)
+                .skinPictureUrl("사진3")
+                .build();
+
+        Diagnosis 진단4 = Diagnosis.builder()
+                .member(member2)
+                .skin(ps4)
+                .skinPictureUrl("사진4")
+                .build();
+
+        Diagnosis 진단5 = Diagnosis.builder()
+                .member(member2)
+                .skin(ts3)
+                .skinPictureUrl("사진5")
+                .build();
+
+        Diagnosis 진단6 = Diagnosis.builder()
+                .member(member2)
+                .skin(tt2)
+                .skinPictureUrl("사진6")
+                .build();
+
+        diagnosisRepository.save(진단1);
+        diagnosisRepository.save(진단2);
+        diagnosisRepository.save(진단3);
+        diagnosisRepository.save(진단4);
+        diagnosisRepository.save(진단5);
+        diagnosisRepository.save(진단6);
+        //when
+
+        Pageable pageable = Pageable.ofSize(10).withPage(0);
+
+        Page<MemberResponse> members = memberRepository.getMembers(pageable);
+
+        //then
+        members.forEach(System.out::println);
+
+    }
+
+}


### PR DESCRIPTION
## QueryDsl 설정 추가 및 관리자 유저 관리 기능
- QueryDsl 설정 추가
- 관리자 유저 전체 조회 및 각 유저별 퍼스널컬러, 트러블, 피부타입 최근 진단 결과 조회 -> 복잡한 쿼리로 인해 querydsl 설정 추가 및 적용
- 관리자 유저 비활성화 -> activated를 false로 하였습니다.