### PR TITLE
fix: Generation strategy 수정 및 진단 시 이미지 파일 오류 수정

### DIFF
--- a/src/main/java/firstskin/firstskin/category/domain/Category.java
+++ b/src/main/java/firstskin/firstskin/category/domain/Category.java
@@ -1,9 +1,6 @@
 package firstskin.firstskin.category.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 public class Category {
 
     @Id
-    @GeneratedValue
     @Column(name = "category_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long categoryId;
 
     private String category;

--- a/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
+++ b/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
@@ -14,7 +14,7 @@ public class Diagnosis extends BaseTimeEntity {
 
     @Id
     @Column(name = "diagnosis_id")
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long diagnosisId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
@@ -180,10 +180,9 @@ public class DiagnosisService {
         }
 
         // 이미지 파일이 아닐 경우 예외
-        List<String> allowedContentType = Arrays.asList("image/png", "image/jpeg", "image/jpg");
-        if (!allowedContentType.contains(request.getFile().getContentType())) {
-            throw new IllegalStateException("PNG, JPEG, JPG 파일만 업로드 가능합니다.");
-        }
+        List<String> allowedContentType = Arrays.asList("png", "jpeg", "jpg");
+        if(!allowedContentType.contains(request.getFile().getOriginalFilename().split("\\.")[1]))
+            throw new IllegalStateException("이미지 파일만 업로드 가능합니다.");
 
         MultipartFile file = request.getFile();
         String originalFilename = file.getOriginalFilename();

--- a/src/main/java/firstskin/firstskin/member/domain/Member.java
+++ b/src/main/java/firstskin/firstskin/member/domain/Member.java
@@ -12,7 +12,7 @@ public class Member extends BaseTimeEntity {
 
     @Id
     @Column(name = "member_id")
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
     @Column(name = "user_id")

--- a/src/main/java/firstskin/firstskin/review/domain/Review.java
+++ b/src/main/java/firstskin/firstskin/review/domain/Review.java
@@ -6,8 +6,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
 @Entity
 @NoArgsConstructor
 @Getter
@@ -15,7 +13,7 @@ public class Review extends BaseTimeEntity {
 
     @Id
     @Column(name = "review_id")
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
+++ b/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
@@ -8,6 +8,7 @@ import firstskin.firstskin.user.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ import static firstskin.firstskin.member.domain.Role.ROLE_USER;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Slf4j
 public class MemberController {
 
     final private MemberService memberService;
@@ -27,6 +29,8 @@ public class MemberController {
 
     @GetMapping("/oauth/kakao/callback")
     public ResponseEntity<String> login(@RequestParam String code, HttpServletRequest httpServletRequest){
+
+        log.info("로그인 요청 받음. code: {}", code);
 
         OauthToken oauthToken = memberService.requestToken(code);
         KakaoProfile kakaoProfile = memberService.requestKakaoProfile(oauthToken);


### PR DESCRIPTION
- Generation strategy를 indentity로 해서 시퀀스 문제 생기는걸 DB에 위임하는 전략으로 변경하였습니다. (모든 엔티티에 해당)
- 진단 시 PNG, JPG, JPEG 타입만 받을 수 있도록 하였는데 그 부분에서 문제가 발생하여 수정하였습니다.