### PR TITLE
chore: 전역 예외 처리 핸들러 구현

### DIFF
--- a/src/main/java/firstskin/firstskin/common/exception/FileNotFound.java
+++ b/src/main/java/firstskin/firstskin/common/exception/FileNotFound.java
@@ -1,0 +1,10 @@
+package firstskin.firstskin.common.exception;
+
+public class FileNotFound extends RuntimeException {
+    public FileNotFound() {
+        super("파일을 찾을 수 없습니다.");
+    }
+    public FileNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/exception/FirstSkinExceptionHandler.java
+++ b/src/main/java/firstskin/firstskin/common/exception/FirstSkinExceptionHandler.java
@@ -1,10 +1,12 @@
 package firstskin.firstskin.common.exception;
 
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,12 +14,52 @@ import java.util.Map;
 @ControllerAdvice
 public class FirstSkinExceptionHandler {
 
+    @ExceptionHandler(MissMatchType.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> missMatchTypeException(MissMatchType e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UserNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<Map<String, String>> userNotFoundException(UserNotFound e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(FileNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<Map<String, String>> fileNotFoundException(FileNotFound e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(UnauthorizedException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ResponseEntity<Map<String, String>> unauthorizedException(UnauthorizedException e) {
         Map<String, String> response = new HashMap<>();
         response.put("message", e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    public ResponseEntity<Map<String, String>> maxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "파일 크기가 너무 큽니다. 최대 10MB까지 업로드 가능합니다.");
+        return new ResponseEntity<>(response, HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> badRequestException(BadRequestException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/firstskin/firstskin/common/exception/FirstSkinExceptionHandler.java
+++ b/src/main/java/firstskin/firstskin/common/exception/FirstSkinExceptionHandler.java
@@ -1,0 +1,30 @@
+package firstskin.firstskin.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class FirstSkinExceptionHandler {
+
+    @ExceptionHandler(UnauthorizedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<Map<String, String>> unauthorizedException(UnauthorizedException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<Map<String, String>> handleGeneralException(Exception e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/exception/MissMatchType.java
+++ b/src/main/java/firstskin/firstskin/common/exception/MissMatchType.java
@@ -1,0 +1,10 @@
+package firstskin.firstskin.common.exception;
+
+public class MissMatchType extends RuntimeException {
+    public MissMatchType() {
+        super("파일이 타입이 올바르지 않습니다.");
+    }
+    public MissMatchType(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/exception/UnauthorizedException.java
+++ b/src/main/java/firstskin/firstskin/common/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package firstskin.firstskin.common.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException() {
+        super("로그인이 필요합니다.");
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/exception/UserNotFound.java
+++ b/src/main/java/firstskin/firstskin/common/exception/UserNotFound.java
@@ -1,0 +1,10 @@
+package firstskin.firstskin.common.exception;
+
+public class UserNotFound extends RuntimeException {
+    public UserNotFound() {
+        super("사용자를 찾을 수 없습니다.");
+    }
+    public UserNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/firstskin/firstskin/dianosis/api/controller/CosmeticController.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/controller/CosmeticController.java
@@ -21,7 +21,7 @@ public class CosmeticController {
     @GetMapping
     public CosmeticPageResponse searchCosmetics(CosmeticRequest request) throws JsonProcessingException {
 
-      log.info("request : {}", request);
+        log.info("request : {}", request);
         return cosmeticService.searchCosmetics(request);
 
     }

--- a/src/main/java/firstskin/firstskin/dianosis/api/controller/DiagnosisController.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/controller/DiagnosisController.java
@@ -1,10 +1,13 @@
 package firstskin.firstskin.dianosis.api.controller;
 
+import firstskin.firstskin.common.exception.UnauthorizedException;
 import firstskin.firstskin.dianosis.api.request.DiagnosisDto;
 import firstskin.firstskin.dianosis.api.response.DiagnosisResponse;
 import firstskin.firstskin.dianosis.service.DiagnosisService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,13 +17,24 @@ import java.io.IOException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/skin/diagnosis")
+@Slf4j
 public class DiagnosisController {
 
     private final DiagnosisService diagnosisService;
 
     @PostMapping
     public DiagnosisResponse diagnosisSkin(DiagnosisDto diagnosisDto, HttpServletRequest request) throws IOException {
-        diagnosisDto.setMemberId((Long) request.getSession().getAttribute("memberId"));
+        HttpSession session = request.getSession(false);
+        log.info("진단 요청 session : {}", session);
+        if (session == null) {
+            throw new UnauthorizedException();
+        }
+        Object memberId = session.getAttribute("memberId");
+        log.info("진단 요청 memberId : {}", memberId);
+        if (memberId == null) {
+            throw new UnauthorizedException();
+        }
+        diagnosisDto.setMemberId((Long) memberId);
         return diagnosisService.diagnosisSkin(diagnosisDto);
     }
 }

--- a/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
@@ -1,5 +1,8 @@
 package firstskin.firstskin.dianosis.service;
 
+import firstskin.firstskin.common.exception.FileNotFound;
+import firstskin.firstskin.common.exception.MissMatchType;
+import firstskin.firstskin.common.exception.UserNotFound;
 import firstskin.firstskin.dianosis.DiagnosisRepository;
 import firstskin.firstskin.dianosis.api.request.DiagnosisDto;
 import firstskin.firstskin.dianosis.api.response.DiagnosisResponse;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import net.coobird.thumbnailator.Thumbnails;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -150,14 +154,14 @@ public class DiagnosisService {
 
         } else if (request.getKind().equals(Kind.PERSONAL_COLOR)) {
             // 퍼스널 컬러 진단
-            throw new IllegalStateException("퍼스널 컬러 진단은 준비 중입니다.");
+            throw new BadRequestException("퍼스널 컬러 진단은 준비 중입니다.");
         } else {
-            throw new IllegalStateException("TROUBLE, TYPE, PERSONAL_COLOR 중 하나를 선택해주세요.");
+            throw new BadRequestException("TROUBLE, TYPE, PERSONAL_COLOR 중 하나를 선택해주세요.");
         }
 
         // DB에 저장
         Member findMember = memberRepository.findById(request.getMemberId())
-                .orElseThrow(() -> new IllegalStateException(request.getMemberId() + " 회원을 찾을 수 없음"));
+                .orElseThrow(() -> new UserNotFound(request.getMemberId() + " 회원을 찾을 수 없음"));
 
         String finalResultLabel = resultLabel;
         Skin findSkin = skinRepository.findByResult(resultLabel).orElseThrow(() -> new IllegalStateException(finalResultLabel + " is not found"));
@@ -176,13 +180,13 @@ public class DiagnosisService {
     private String saveFile(DiagnosisDto request) {
 
         if (request.getFile().isEmpty()) {
-            throw new IllegalStateException("업로드된 파일이 없습니다.");
+            throw new FileNotFound("업로드된 파일이 없습니다.");
         }
 
         // 이미지 파일이 아닐 경우 예외
         List<String> allowedContentType = Arrays.asList("png", "jpeg", "jpg");
         if(!allowedContentType.contains(request.getFile().getOriginalFilename().split("\\.")[1]))
-            throw new IllegalStateException("이미지 파일만 업로드 가능합니다.");
+            throw new MissMatchType("이미지 파일만 업로드 가능합니다.");
 
         MultipartFile file = request.getFile();
         String originalFilename = file.getOriginalFilename();
@@ -285,7 +289,7 @@ public class DiagnosisService {
         } else if (kind.equals(Kind.TROUBLE)) {
             return Paths.get(uploadDir, "skintrouble", "customers", year, month, day);
         } else {
-            throw new IllegalStateException("TROUBLE, TYPE 중 하나를 선택해주세요.");
+            throw new MissMatchType("TROUBLE, TYPE 중 하나를 선택해주세요.");
         }
     }
 

--- a/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
+++ b/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
@@ -65,6 +65,7 @@ public class MemberController {
 
         HttpSession session = request.getSession(false);
         if (session != null) {
+            log.info("로그아웃 memberId: {}", session.getAttribute("memberId"));
             session.invalidate();
         }
 

--- a/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
+++ b/src/main/java/firstskin/firstskin/user/api/contorller/MemberController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public class MemberController {
     final private MemberService memberService;
 
     @GetMapping("/oauth/kakao/callback")
-    public ResponseEntity<String> login(@RequestParam String code, HttpServletRequest httpServletRequest){
+    public ResponseEntity<String> login(@RequestParam String code, HttpServletRequest httpServletRequest) {
 
         log.info("로그인 요청 받음. code: {}", code);
 
@@ -36,10 +35,14 @@ public class MemberController {
         KakaoProfile kakaoProfile = memberService.requestKakaoProfile(oauthToken);
 
         Member findMember = memberService.findMemberByUserId(kakaoProfile.getId().toString());
-        if (findMember!=null) {
+        if (findMember != null) {
+
+            log.info("==기존 회원 로그인==");
             memberService.sessionSave(httpServletRequest, findMember, oauthToken);
+            log.info("기존 회원 로그인. userId: {}", findMember.getUserId());
             return ResponseEntity.status(200).body("login");
         } else {
+            log.info("==신규 회원 가입==");
             Member newMember = new Member(
                     ROLE_USER,
                     kakaoProfile.getKakao_account().getProfile().getProfile_image_url(),
@@ -48,9 +51,12 @@ public class MemberController {
 
             memberService.addMember(newMember);
             memberService.sessionSave(httpServletRequest, newMember, oauthToken);
+
+            log.info("신규 회원 가입. userId: {}", newMember.getUserId());
             return ResponseEntity.status(200).body("new-member");
         }
     }
+
     @GetMapping("/logout-kakao")
     public ResponseEntity<String> logoutKakao(HttpServletRequest request) {
         String accessToken = (String) request.getSession().getAttribute("access_token");
@@ -58,13 +64,14 @@ public class MemberController {
         memberService.logoutRequest(accessToken);
 
         HttpSession session = request.getSession(false);
-        if(session != null) {
+        if (session != null) {
             session.invalidate();
         }
 
         return ResponseEntity.status(HttpStatus.OK).body("Logged-out-successfully");
 
     }
+
     @GetMapping("/members")
     public ResponseEntity<List<MemberDto>> getAllMembers() {
         List<MemberDto> members = memberService.getAllMembers();
@@ -73,19 +80,30 @@ public class MemberController {
     }
 
     @GetMapping("/members/{memberId}")
-    public ResponseEntity<Optional<MemberDto>> getMember(@PathVariable Long memberId){
+    public ResponseEntity<Optional<MemberDto>> getMember(@PathVariable Long memberId) {
         Optional<MemberDto> member = memberService.getMemberById(memberId);
         return ResponseEntity.status(HttpStatus.OK).body(member);
     }
 
     @PutMapping("/members/{memberId}")
     public ResponseEntity<String> updateProfile(@PathVariable Long memberId, @RequestBody MemberDto memberDto) {
-            memberService.updateProfile(memberId, memberDto);
-            return ResponseEntity.ok("Profile updated successfully");
+        memberService.updateProfile(memberId, memberDto);
+        return ResponseEntity.ok("Profile updated successfully");
 
     }
 
-
+    @GetMapping("/members/is-login")
+    public ResponseEntity<String> isLogin(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+        Object memberId = session.getAttribute("memberId");
+        if (memberId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+        return ResponseEntity.status(HttpStatus.OK).body("로그인 되어있습니다. memberId: " + memberId);
+    }
 }
 
 

--- a/src/main/java/firstskin/firstskin/user/api/contorller/ReviewController.java
+++ b/src/main/java/firstskin/firstskin/user/api/contorller/ReviewController.java
@@ -1,18 +1,14 @@
 package firstskin.firstskin.user.api.contorller;
 
-import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.review.domain.Review;
 import firstskin.firstskin.user.api.dto.UpdateReview;
-import firstskin.firstskin.user.service.MemberService;
 import firstskin.firstskin.user.service.ReviewService;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
-@RequestMapping("/reviews")
+@RequestMapping("/api/reviews")
 public class ReviewController {
 
     private final ReviewService reviewService;

--- a/src/main/java/firstskin/firstskin/user/service/MemberService.java
+++ b/src/main/java/firstskin/firstskin/user/service/MemberService.java
@@ -9,6 +9,7 @@ import firstskin.firstskin.model.OauthToken;
 import firstskin.firstskin.user.api.dto.MemberDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -22,9 +23,9 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.Optional;
 
 @Service
+@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -98,11 +99,9 @@ public class MemberService {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type","authorization_code");
         params.add("client_id","c33ec31ce21c44a27c43a6165664cb5a");
-        params.add("redirect_uri","http://localhost:8080/api/oauth/kakao/callback");
+        params.add("redirect_uri","http://ceprj.gachon.ac.kr:60022/api/oauth/kakao/callback");
         params.add("code",code);
 
-        System.out.println("인가 코드: " + code);
-        System.out.println("메서드");
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -158,6 +157,8 @@ public class MemberService {
         session.setAttribute("memberId", member.getMemberId());
         session.setAttribute("access_token", oauthToken.getAccess_token());
         session.setMaxInactiveInterval(3600);
+        log.info("세션 저장 완료. memberId: {}", member.getMemberId());
+        log.info("저장된 memberId 세션: {}", session.getAttribute("memberId"));
         return session;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,12 +10,15 @@ spring:
     open-in-view: true
     hibernate:
       ddl-auto: none
-
-
     properties:
       hibernate:
         format_sql: true
         use_sql_comments: true
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 logging:
   level:


### PR DESCRIPTION
## 전역 예외 처리 핸들러 구현
### FirstSkinExceptionHandler
- 예외 처리를 통해 에러 메세지를 클라이언트에게 보냄
- ```@ControllerAdvice``` 사용
### 커스텀 예외
- ```FileNotFound``` 파일을 찾을 수 없을 때. 404
- ```MissMatchType``` 파일 형식이 잘못됐을 때. 400
- ```UserNotFoundException``` 유저를 찾을 수 없을 때. 404
- ```UnauthorizedException``` 로그인 안됐을 때. 401
### 기존 예외
- ```MaxUploadSizeExceededException``` 파일 크기 초과. 413
- ```BadRequestException``` 400
- ```Exception``` 500
## request 파일 크기 변경
- yml에 추가하여 10MB까지 받을 수 있도록 함
## endpoint 변경
- review api의 엔드 포인트가 ```/review```로 되어 있어 ```/api/review```로 변경