### PR TITLE
refactor-category목록 조회 api 엔드포인트 수정. -> /api/category

### DIFF
--- a/src/main/java/firstskin/firstskin/admin/api/controller/CategoryController.java
+++ b/src/main/java/firstskin/firstskin/admin/api/controller/CategoryController.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin")
+@RequestMapping("/api")
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -20,17 +20,17 @@ public class CategoryController {
         return categoryService.getAllCategories();
     }
 
-    @PostMapping("/category")
+    @PostMapping("/admin/category")
     public void addCategory(String category) {
         categoryService.addCategory(category);
     }
 
-    @PutMapping("/category")
+    @PutMapping("/admin/category")
     public void updateCategory(EditCategory category) {
         categoryService.editCategory(category);
     }
 
-    @DeleteMapping("/category/{categoryId}")
+    @DeleteMapping("/admin/category/{categoryId}")
     public void deleteCategory(@PathVariable Long categoryId) {
         categoryService.deleteCategory(categoryId);
     }

--- a/src/main/java/firstskin/firstskin/admin/api/controller/RestudyController.java
+++ b/src/main/java/firstskin/firstskin/admin/api/controller/RestudyController.java
@@ -1,0 +1,26 @@
+package firstskin.firstskin.admin.api.controller;
+
+import firstskin.firstskin.admin.api.dto.request.RestudyRequest;
+import firstskin.firstskin.admin.service.RestudyService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/restudy")
+@Slf4j
+@RequiredArgsConstructor
+public class RestudyController {
+
+    private final RestudyService restudyService;
+
+    @PostMapping
+    @Operation(summary = "재학습")
+    public void restudy(@RequestBody RestudyRequest request) {
+        restudyService.restudy(request);
+    }
+}

--- a/src/main/java/firstskin/firstskin/admin/api/dto/request/RestudyRequest.java
+++ b/src/main/java/firstskin/firstskin/admin/api/dto/request/RestudyRequest.java
@@ -1,0 +1,26 @@
+package firstskin.firstskin.admin.api.dto.request;
+
+import firstskin.firstskin.skin.Kind;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RestudyRequest {
+
+    @Schema(description = "재학습 종류", example = "TYPE or PERSONAL_COLOR or TROUBLE or 타입")
+    private final Kind kind;
+
+    @Schema(description = "모델 경로", example = "/home/firstskin/model/firstskin_model.h5")
+    private final String modelPath;
+
+    @Schema(description = "CSV 파일 경로", example = "/home/firstskin/csv/firstskin.csv")
+    private final String dfPath;
+
+    @Builder
+    public RestudyRequest(Kind kind, String modelPath, String csvPath) {
+        this.kind = kind;
+        this.modelPath = modelPath;
+        this.dfPath = csvPath;
+    }
+}

--- a/src/main/java/firstskin/firstskin/admin/service/RestudyService.java
+++ b/src/main/java/firstskin/firstskin/admin/service/RestudyService.java
@@ -1,0 +1,50 @@
+package firstskin.firstskin.admin.service;
+
+import firstskin.firstskin.admin.api.dto.request.RestudyRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@Service
+@Slf4j
+public class RestudyService {
+
+    @Value("${python.restudy_path}")
+    private String restudyPath;
+
+    public void restudy(RestudyRequest request) {
+        log.info("{} 재학습 시작, 모델 경로: {}, df 경로: {}", request.getKind(), request.getModelPath(), request.getDfPath());
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder("python3", restudyPath, request.getModelPath(), request.getDfPath());
+            pb.redirectErrorStream(true);
+
+            log.info("재학습 명령어: {}", pb.command());
+
+            Process p = pb.start();
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    log.info("재학습 로그: {}", line);
+                    sb.append(line).append("\n");
+                }
+            }
+
+            log.info("재학습 결과: {}", sb);
+
+            int exitCode = p.waitFor();
+            if (exitCode != 0) {
+                throw new InternalError("재학습 실패. 파이썬 스크립트에서 오류가 발생했습니다. exitCode: " + exitCode);
+            }
+
+        } catch (IOException | InterruptedException exception) {
+            log.error("재학습 실패", exception);
+            throw new InternalError("서버 오류로 인한 재학습 실패.");
+        }
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/component/ModelPathResolver.java
+++ b/src/main/java/firstskin/firstskin/common/component/ModelPathResolver.java
@@ -1,0 +1,60 @@
+package firstskin.firstskin.common.component;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Component
+public class ModelPathResolver {
+
+    // 각 모델 경로 및 패턴은 application.yml에서 설정
+    @Value("${model.type}")
+    private String typePath;
+
+    @Value("${model.type_pattern}")
+    private String typePattern;
+
+    @Value("${model.trouble}")
+    private String troublePath;
+
+    @Value("${model.trouble_pattern}")
+    private String troublePattern;
+
+    @Value("${model.personal_color}")
+    private String personalPath;
+
+    @Value("${model.personal_color_pattern}")
+    private String personalColorPattern;
+
+
+    public String resolveModelPath(String basePath, String pattern) {
+        File dir = new File(basePath);
+        if (!dir.exists() || !dir.isDirectory()) {
+            throw new IllegalStateException("Directory does not exist: " + basePath);
+        }
+        Pattern regex = Pattern.compile(pattern.replace("*", ".*"));
+        return Arrays.stream(Objects.requireNonNull(dir.listFiles()))
+                .filter(file -> regex.matcher(file.getName()).matches())
+                .max(Comparator.comparingLong(File::lastModified))
+                .map(File::getAbsolutePath)
+                .orElseThrow(() -> new IllegalStateException("No model file found matching pattern: " + pattern));
+    }
+
+    // 각 모델 타입에 대한 특정 메소드를 제공하지 않고, 각 설정에 맞는 경로 해석을 수행
+    public String resolveTypeModelPath() {
+        return resolveModelPath(typePath, typePattern);
+    }
+
+    public String resolveTroubleModelPath() {
+        return resolveModelPath(troublePath, troublePattern);
+    }
+
+    public String resolvePersonalColorModelPath() {
+        return resolveModelPath(personalPath, personalColorPattern);
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/config/CorsConfig.java
+++ b/src/main/java/firstskin/firstskin/common/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package firstskin.firstskin.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/controller/FileController.java
+++ b/src/main/java/firstskin/firstskin/common/controller/FileController.java
@@ -1,0 +1,45 @@
+package firstskin.firstskin.common.controller;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+public class FileController {
+
+    @GetMapping("/api/files")
+    public ResponseEntity<Resource> serveFile(@RequestParam String path) {
+        try {
+            // 클라이언트가 요청한 경로를 사용하여 파일 경로 설정
+            Path file = Paths.get(path);
+            Resource resource = new UrlResource(file.toUri());
+
+            if (resource.exists() || resource.isReadable()) {
+                // 파일의 MIME 타입을 결정
+                String mimeType = Files.probeContentType(file);
+                if (mimeType == null) {
+                    mimeType = "application/octet-stream";
+                }
+
+                return ResponseEntity.ok()
+                        .contentType(MediaType.parseMediaType(mimeType))
+                        .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + resource.getFilename() + "\"")
+                        .body(resource);
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+
+    }
+}

--- a/src/main/java/firstskin/firstskin/common/controller/WebController.java
+++ b/src/main/java/firstskin/firstskin/common/controller/WebController.java
@@ -1,0 +1,13 @@
+package firstskin.firstskin.common.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class WebController {
+
+    @GetMapping("/admin")
+    public String forwardAdmin() {
+        return "forward:/web/admin/index.html";  // URL을 유지하면서 내부적으로 전달
+    }
+}

--- a/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
+++ b/src/main/java/firstskin/firstskin/dianosis/domain/Diagnosis.java
@@ -6,9 +6,11 @@ import firstskin.firstskin.skin.Skin;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Diagnosis extends BaseTimeEntity {
 

--- a/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/DiagnosisService.java
@@ -1,5 +1,6 @@
 package firstskin.firstskin.dianosis.service;
 
+import firstskin.firstskin.common.component.ModelPathResolver;
 import firstskin.firstskin.common.exception.FileNotFound;
 import firstskin.firstskin.common.exception.MissMatchType;
 import firstskin.firstskin.common.exception.UserNotFound;
@@ -51,16 +52,17 @@ public class DiagnosisService {
     private final DiagnosisRepository diagnosisRepository;
     private final MemberRepository memberRepository;
     private final SkinRepository skinRepository;
+    private final ModelPathResolver modelPathResolver;
 
     @Value("${file.upload-dir}")
     private String uploadDir;
 
-    @Value("${model.type}")
-    private String typeModelPath;
-
-    @Value("${model.trouble}")
-    private String troubleModelPath;
-
+//    @Value("${model.type}")
+//    private String typeModelPath;
+//
+//    @Value("${model.trouble}")
+//    private String troubleModelPath;
+//
     @Value("${model.detect_trouble}")
     private String detectTroubleModelPath;
 
@@ -70,6 +72,9 @@ public class DiagnosisService {
 
     @PostConstruct
     public void init() {
+        String typeModelPath = modelPathResolver.resolveTypeModelPath();
+        String troubleModelPath = modelPathResolver.resolveTroubleModelPath();
+
         typeModel = SavedModelBundle.load(typeModelPath, "serve");
         troubleModel = SavedModelBundle.load(troubleModelPath, "serve");
         detectTroubleModel = SavedModelBundle.load(detectTroubleModelPath, "serve");

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import firstskin.firstskin.admin.api.dto.response.MemberResponse;
+import firstskin.firstskin.dianosis.domain.QDiagnosis;
 import firstskin.firstskin.skin.Kind;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -49,13 +50,38 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return new PageImpl<>(fetch, pageable, count == null ? 0 : count);
     }
 
-    private static JPQLQuery<String> selectKindOfSkin(Kind type) {
-        return JPAExpressions
-                .select(skin.result)
-                .from(diagnosis)
-                .join(diagnosis.skin, skin)
-                .where(diagnosis.member.eq(member).and(skin.kind.eq(type)))
-                .orderBy(diagnosis.createdDate.desc())
-                .limit(1);
-    }
+//    private static JPQLQuery<String> selectKindOfSkin(Kind type) {
+//        return JPAExpressions
+//                .select(skin.result)
+//                .from(diagnosis)
+//                .join(diagnosis.skin, skin)
+//                .where(diagnosis.member.eq(member)
+//                        .and(skin.kind.eq(type))
+//                        .and(diagnosis.createdDate.eq(
+//                                JPAExpressions
+//                                        .select(diagnosis.createdDate.max())
+//                                        .from(diagnosis)
+//                                        .where(diagnosis.member.eq(member)
+//                                                .and(skin.kind.eq(type)))
+//                        )));
+////                .orderBy(diagnosis.createdDate.desc())
+////                .limit(1);
+//    }
+private JPQLQuery<String> selectKindOfSkin(Kind kind) {
+    QDiagnosis subDiagnosis = new QDiagnosis("subDiagnosis");
+
+    return JPAExpressions
+            .select(skin.result)
+            .from(diagnosis)
+            .join(diagnosis.skin, skin)
+            .where(diagnosis.member.eq(member)
+                    .and(skin.kind.eq(kind))
+                    .and(diagnosis.createdDate.eq(
+                            JPAExpressions
+                                    .select(subDiagnosis.createdDate.max())
+                                    .from(subDiagnosis)
+                                    .where(subDiagnosis.member.eq(member)
+                                            .and(subDiagnosis.skin.kind.eq(kind)))
+                    )));
+}
 }

--- a/src/main/java/firstskin/firstskin/user/api/contorller/ReviewController.java
+++ b/src/main/java/firstskin/firstskin/user/api/contorller/ReviewController.java
@@ -1,14 +1,15 @@
 package firstskin.firstskin.user.api.contorller;
 
+import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.review.domain.Review;
 import firstskin.firstskin.user.api.dto.AddReviewDto;
-import firstskin.firstskin.user.api.dto.MemberDto;
 import firstskin.firstskin.user.api.dto.UpdateReview;
+import firstskin.firstskin.user.service.MemberService;
 import firstskin.firstskin.user.service.ReviewService;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/reviews")

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h2>이건 내부</h2>
+</body>
+</html>

--- a/src/test/java/firstskin/firstskin/admin/api/controller/CategoryControllerTest.java
+++ b/src/test/java/firstskin/firstskin/admin/api/controller/CategoryControllerTest.java
@@ -36,7 +36,7 @@ class CategoryControllerTest {
         categoryRepository.save(new Category("립"));
 
         //expected
-        mockMvc.perform(get("/api/admin/category")
+        mockMvc.perform(get("/api/category")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
@@ -51,7 +51,7 @@ class CategoryControllerTest {
         String category = "선크림";
 
         //expected
-        mockMvc.perform(get("/api/admin/category")
+        mockMvc.perform(get("/api/category")
                         .param("category", category)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -67,7 +67,7 @@ class CategoryControllerTest {
         categoryRepository.save(category);
 
         //expected
-        mockMvc.perform(get("/api/admin/category")
+        mockMvc.perform(get("/api/category")
                         .param("categoryId", String.valueOf(category.getCategoryId()))
                         .param("category", "선크림")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -82,7 +82,7 @@ class CategoryControllerTest {
         //given
         Category category = new Category("스킨/로션");
         categoryRepository.save(category);
-        mockMvc.perform(get("/api/admin/category")
+        mockMvc.perform(get("/api/category")
                         .param("categoryId", String.valueOf(category.getCategoryId()))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/firstskin/firstskin/admin/service/RestudyServiceTest.java
+++ b/src/test/java/firstskin/firstskin/admin/service/RestudyServiceTest.java
@@ -1,0 +1,32 @@
+//package firstskin.firstskin.admin.service;
+//
+//import firstskin.firstskin.admin.api.dto.request.RestudyRequest;
+//import firstskin.firstskin.skin.Kind;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class RestudyServiceTest {
+//
+//    @Autowired
+//    private RestudyService restudyService;
+//
+//    @Test
+//    @DisplayName("재학습 하기")
+//    public void restudyType() throws Exception{
+//        //given
+//        RestudyRequest request = RestudyRequest.builder()
+//                .kind(Kind.TYPE)
+//                .modelPath("/Users/wonu/Desktop/jarr/skintype_v1.h5")
+//                .csvPath("/Users/wonu/Desktop/t24122/aidata/skintype/skintype_df.csv")
+//                .build();
+//        //when
+//        restudyService.restudy(request);
+//
+//        //then
+//
+//    }
+//
+//}

--- a/src/test/java/firstskin/firstskin/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/firstskin/firstskin/member/repository/MemberRepositoryImplTest.java
@@ -116,6 +116,7 @@ class MemberRepositoryImplTest {
         diagnosisRepository.save(진단4);
         diagnosisRepository.save(진단5);
         diagnosisRepository.save(진단6);
+        diagnosisRepository.save(진단66);
         //when
 
         Pageable pageable = Pageable.ofSize(10).withPage(0);


### PR DESCRIPTION
## refactor
### category 목록 조회 endpoint 수정
- ```/api/admin/category``` -> ```/api/category```
### member 조회 서브쿼리 수정
- ```limit(1)``` 사용 시 서브쿼리에서 이게 적용되지 않고 여러 개의 결과가 반환되어 수정

## feat
### restudy
- restudy 기능 추가
- 모델 이슈로 재확인 필요
### 진단 모델 경로 설정
- v1, v2, ... 등을 자동으로 최신 으로 가져오도록 함
### frontend 뷰 리졸버 설정
- 리액트 정적 리소스 라우팅 설정
- ```/admin``` 으로 진입 시 ```/web/admin``` 에서 정적 리소스 가져오도록 함

## chore: ```secure-submodule/application-dev.yml```
- 아래 내용 본인 로컬에 맞게 수정해서 추가해주세요. 본인이 설정한 경로에 모델이랑 파이썬 스크립트 넣으시면 됩니다
```
spring:
  web:
    resources:
      static-locations: file:///Users/wonu/Desktop/jarr/static_resource/
      
### tensorflow model path
model:
  type: /Users/wonu/study/2024-1/first_skin_model/type/
  type_pattern: skintype_v*
  trouble: /Users/wonu/study/2024-1/first_skin_model/trouble/
  trouble_pattern: skintrouble_v*
  detect_trouble: /Users/wonu/study/2024-1/first_skin_model/detect_trouble/saved_model
  personal_color: /Users/wonu/study/2024-1/first_skin_model/personal_color/
  personal_color_pattern: personalcolor_v*

### 재학습 파이썬 코드
python:
  restudy_path: /Users/wonu/Desktop/jarr/restudy.py
  ```