### PR TITLE
fix: personalcolor search

### DIFF
--- a/src/main/java/firstskin/firstskin/admin/service/RestudyService.java
+++ b/src/main/java/firstskin/firstskin/admin/service/RestudyService.java
@@ -20,13 +20,15 @@ public class RestudyService {
     private String restudyPath;
 
     public RestudyResponse restudy(RestudyRequest request) {
-        log.info("{} 재학습 시작, 모델 경로: {}, df 경로: {}", request.getKind(), request.getModelPath(), request.getDfPath());
+        log.info("{} 재학습 시작, 모델 경로: {}, df 경로: {}",
+                request.getKind(), request.getModelPath(), request.getDfPath());
 
         List<String> lastTwoLines = new LinkedList<>();
         StringBuilder completeLog = new StringBuilder();
 
         try {
-            ProcessBuilder pb = new ProcessBuilder("python3", restudyPath, request.getModelPath(), request.getDfPath(), request.getKind().toString());
+            ProcessBuilder pb = new ProcessBuilder("python3", restudyPath,
+                    request.getModelPath(), request.getDfPath(), request.getKind().toString());
             pb.redirectErrorStream(true);
 
             log.info("재학습 명령어: {}", pb.command());

--- a/src/main/java/firstskin/firstskin/common/component/AuthInterceptor.java
+++ b/src/main/java/firstskin/firstskin/common/component/AuthInterceptor.java
@@ -33,10 +33,10 @@ public class AuthInterceptor implements HandlerInterceptor {
         //진단
         addUri("/api/skin/diagnosis", POST, ROLE_USER)
                 //관리자
-//                .addUri("/api/admin", GET, ROLE_ADMIN)
-//                .addUri("/api/admin", POST, ROLE_ADMIN)
-//                .addUri("/api/admin", DELETE, ROLE_ADMIN)
-//                .addUri("/api/admin", PUT, ROLE_ADMIN)
+                .addUri("/api/admin", GET, ROLE_ADMIN)
+                .addUri("/api/admin", POST, ROLE_ADMIN)
+                .addUri("/api/admin", DELETE, ROLE_ADMIN)
+                .addUri("/api/admin", PUT, ROLE_ADMIN)
                 // 유저 정보 수정
                 .addUri("/api/members", PUT, ROLE_ADMIN)
                 .addUri("/api/members", PUT, ROLE_USER)

--- a/src/main/java/firstskin/firstskin/common/constants/DfPath.java
+++ b/src/main/java/firstskin/firstskin/common/constants/DfPath.java
@@ -1,0 +1,13 @@
+package firstskin.firstskin.common.constants;
+
+import lombok.Getter;
+
+@Getter
+public class DfPath {
+
+    public static final String TYPE_PATH = "skintype/skintype_df.csv";
+
+    public static final String TROUBLE_PATH = "skintrouble/skintrouble_df.csv";
+
+    public static final String PERSONAL_COLOR_PATH = "personal_color/personalcolor_df.csv";
+}

--- a/src/main/java/firstskin/firstskin/common/constants/Operation.java
+++ b/src/main/java/firstskin/firstskin/common/constants/Operation.java
@@ -1,0 +1,19 @@
+package firstskin.firstskin.common.constants;
+
+import lombok.Getter;
+
+@Getter
+public class Operation {
+
+    public static final String TYPE_INPUT = "serving_default_input_17";
+
+    public static final String TYPE_OUTPUT = "StatefulPartitionedCall:0";
+
+    public static final String TROUBLE_INPUT = "serving_default_input_5";
+
+    public static final String TROUBLE_OUTPUT = "StatefulPartitionedCall:0";
+
+    public static final String PERSONAL_COLOR_INPUT = "serving_default_dense_3_input:0";
+
+    public static final String PERSONAL_COLOR_OUTPUT = "StatefulPartitionedCall:0";
+}

--- a/src/main/java/firstskin/firstskin/dianosis/api/controller/CosmeticController.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/controller/CosmeticController.java
@@ -5,6 +5,7 @@ import firstskin.firstskin.common.exception.UnauthorizedException;
 import firstskin.firstskin.dianosis.api.request.CosmeticPersonal;
 import firstskin.firstskin.dianosis.api.request.CosmeticRequest;
 import firstskin.firstskin.dianosis.api.response.CosmeticPageResponse;
+import firstskin.firstskin.dianosis.api.response.PersonalResult;
 import firstskin.firstskin.dianosis.service.CosmeticService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +46,21 @@ public class CosmeticController {
         log.info("화장품 검색 memberId : {}", memberId);
         return cosmeticService.searchPersonalCosmetics(memberId, request);
 
+    }
+
+    @GetMapping("/personal/results")
+    public PersonalResult getPersonalResults(HttpSession session) {
+
+        if (session == null) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        Long memberId = (Long) session.getAttribute("memberId");
+
+        if (memberId == null) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        return cosmeticService.getPersonalResults(memberId);
     }
 }

--- a/src/main/java/firstskin/firstskin/dianosis/api/request/CosmeticPersonalRequest.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/request/CosmeticPersonalRequest.java
@@ -17,9 +17,9 @@ public class CosmeticPersonalRequest {
     public CosmeticPersonalRequest(String type, String personalColor, String trouble, String category, Integer start, Integer size, String sort) {
         size = size == null ? 10 : size;
         type = type == null ? "" : "피부타입: " + type + "%20";
-        personalColor = personalColor == null ? "" : "퍼스널컬러: " + personalColor + "%20";
+        personalColor = personalColor == null ? "" : personalColor + "%20";
         trouble = trouble == null ? "" : "트러블: " + trouble + "%20";
-        this.query = type + personalColor + trouble + category;
+        this.query = type + personalColor + trouble + category + "%20화장품";
         this.size = size;
         this.sort = sort;
         this.start = start;

--- a/src/main/java/firstskin/firstskin/dianosis/api/request/CosmeticRequest.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/request/CosmeticRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import static firstskin.firstskin.skin.Kind.PERSONAL_COLOR;
+
 @Getter
 @ToString
 public class CosmeticRequest {
@@ -19,8 +21,11 @@ public class CosmeticRequest {
     public CosmeticRequest(Kind kind, String category, String query, Integer page, Integer size, String sort) {
         size = size == null ? 10 : size;
         this.kind = kind;
-        String kindName = kind == null ? "" : kind.getDescription();
-        this.query = kindName + ":" + query + "%20" + category;
+        String kindName = kind == null ? "" : kind.getDescription() + ":";
+        if (kind == PERSONAL_COLOR) {
+            kindName = "";
+        }
+        this.query = kindName + query + "%20" + category + "%20화장품/미용";
         this.size = size;
         this.sort = sort;
         this.start = Math.max((page == null ? 1 : page - 1) * size + 1, 1);

--- a/src/main/java/firstskin/firstskin/dianosis/api/response/CosmeticResponse.java
+++ b/src/main/java/firstskin/firstskin/dianosis/api/response/CosmeticResponse.java
@@ -1,19 +1,18 @@
 package firstskin.firstskin.dianosis.api.response;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CosmeticResponse {
 
-    private final String title;
-    private final String link;
-    private final String image;
-    private final int lprice;
-    private final long productId;
-    private final String brand;
+    private String title;
+    private String link;
+    private String image;
+    private int lprice;
+    private long productId;
+    private String brand;
 
     private Double score;
 
@@ -25,6 +24,10 @@ public class CosmeticResponse {
         this.lprice = lprice;
         this.productId = productId;
         this.brand = brand;
+        this.score = score;
+    }
+
+    public void setScore(Double score) {
         this.score = score;
     }
 }

--- a/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
@@ -45,19 +45,18 @@ public class CosmeticService {
     public CosmeticPageResponse searchCosmetics(CosmeticRequest request) throws JsonProcessingException {
 
         ResponseEntity<String> exchange = getStringResponseEntity(request);
-//        log.info("네이버 쇼핑 API 응답 === {}", exchange.getBody());
 
         // DTO로 변환
         JsonNode jsonNode = objectMapper.readTree(exchange.getBody());
         JsonNode items = jsonNode.path("items");
 
-        List<CosmeticResponse> cosmeticResponses = objectMapper.readValue(items.toString(), new TypeReference<>() {
+        List<CosmeticResponse> cosmeticResponses = objectMapper.readValue(items
+                .toString(), new TypeReference<>() {
         });
 
         cosmeticResponses
-                .forEach(cosmeticResponse -> {
-                    cosmeticResponse.setScore(reviewRepository.findAvgScoreByProductId(cosmeticResponse.getProductId()));
-                });
+                .forEach(cosmeticResponse -> cosmeticResponse.setScore(reviewRepository
+                        .findAvgScoreByProductId(cosmeticResponse.getProductId())));
 
         return CosmeticPageResponse.builder()
                 .total(jsonNode.path("total").asLong())
@@ -106,9 +105,7 @@ public class CosmeticService {
         });
 
         cosmeticResponses
-                .forEach(cosmeticResponse -> {
-                    cosmeticResponse.setScore(reviewRepository.findAvgScoreByProductId(cosmeticResponse.getProductId()));
-                });
+                .forEach(cosmeticResponse -> cosmeticResponse.setScore(reviewRepository.findAvgScoreByProductId(cosmeticResponse.getProductId())));
 
         return CosmeticPageResponse.builder()
                 .total(objectMapper.readTree(exchange.getBody()).path("total").asLong())

--- a/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
@@ -13,6 +13,7 @@ import firstskin.firstskin.dianosis.api.response.CosmeticResponse;
 import firstskin.firstskin.dianosis.api.response.PersonalResult;
 import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.member.repository.MemberRepository;
+import firstskin.firstskin.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ public class CosmeticService {
     private final ObjectMapper objectMapper;
 
     private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
 
     public CosmeticPageResponse searchCosmetics(CosmeticRequest request) throws JsonProcessingException {
 
@@ -51,6 +53,11 @@ public class CosmeticService {
 
         List<CosmeticResponse> cosmeticResponses = objectMapper.readValue(items.toString(), new TypeReference<>() {
         });
+
+        cosmeticResponses
+                .forEach(cosmeticResponse -> {
+                    cosmeticResponse.setScore(reviewRepository.findAvgScoreByProductId(cosmeticResponse.getProductId()));
+                });
 
         return CosmeticPageResponse.builder()
                 .total(jsonNode.path("total").asLong())
@@ -97,6 +104,11 @@ public class CosmeticService {
 
         List<CosmeticResponse> cosmeticResponses = objectMapper.readValue(items.toString(), new TypeReference<>() {
         });
+
+        cosmeticResponses
+                .forEach(cosmeticResponse -> {
+                    cosmeticResponse.setScore(reviewRepository.findAvgScoreByProductId(cosmeticResponse.getProductId()));
+                });
 
         return CosmeticPageResponse.builder()
                 .total(objectMapper.readTree(exchange.getBody()).path("total").asLong())

--- a/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
+++ b/src/main/java/firstskin/firstskin/dianosis/service/CosmeticService.java
@@ -151,4 +151,9 @@ public class CosmeticService {
 
         return restTemplate.exchange(req, String.class);
     }
+
+    public PersonalResult getPersonalResults(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(UserNotFound::new);
+        return memberRepository.getPersonalResults(member);
+    }
 }

--- a/src/main/java/firstskin/firstskin/member/repository/MemberRepository.java
+++ b/src/main/java/firstskin/firstskin/member/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Member findByUserId(String userId);
     List<Member> findByRole(Role role);
 

--- a/src/main/java/firstskin/firstskin/review/repository/ReviewRepository.java
+++ b/src/main/java/firstskin/firstskin/review/repository/ReviewRepository.java
@@ -1,16 +1,18 @@
 package firstskin.firstskin.review.repository;
 
-import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.review.domain.Review;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByProductId(Long productId, Sort score);
     List<Review> findByProductId(Long productId);
 
     List<Review> findByMember_MemberId(Long memberId);
+
+    @Query("SELECT AVG(r.score) FROM Review r WHERE r.productId = :productId")
+    Double findAvgScoreByProductId(Long productId);
 }

--- a/src/main/java/firstskin/firstskin/user/service/MemberService.java
+++ b/src/main/java/firstskin/firstskin/user/service/MemberService.java
@@ -178,7 +178,6 @@ public class MemberService {
         return session;
     }
 
-<<<<<<< admin-login -- Incoming Change
     public HttpSession sessionSave(HttpServletRequest httpServletRequest, Member member) {
         httpServletRequest.getSession().invalidate();
         HttpSession session = httpServletRequest.getSession(true);
@@ -189,7 +188,8 @@ public class MemberService {
         log.info("저장된 관리자 memberId 세션: {}", session.getAttribute("memberId"));
         log.info("저장된 관리자 member Role 세션: {}", session.getAttribute("role"));
         return session;
-=======
+    }
+
     public boolean hasRole(HttpServletRequest request, Role role) {
         HttpSession session = request.getSession(false);
         if (session == null) {
@@ -197,9 +197,7 @@ public class MemberService {
         }
         Role sessionRole = (Role) session.getAttribute("role");
         return role.equals(sessionRole);
->>>>>>> dev -- Current Change
     }
 
 
-    }
-
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,9 @@ logging:
     org.hibernate.type: trace
   messages:
     basename: errors
+  file:
+    path: /home/t24122/logs
+  config: classpath:logback-spring.xml
 
 pagination:
   size: 20

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- Spring Boot의 프로퍼티 값을 참조 -->
+    <springProperty name="LOG_FILE_PATH" source="logging.file.path" defaultValue="/default/path/to/logs"/>
+
+    <!-- 컬러 패턴 레이아웃 정의 -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+
+    <!-- 콘솔에 로그 출력, 색상 추가 -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} [%thread] %highlight(%-5level){TRACE=blue,DEBUG=green,INFO=cyan,WARN=yellow,ERROR=red} %clr(%logger{36}){magenta} - %msg%n%wex</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일에 로그 출력, 매일 자정에 로그 파일 분할 -->
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE_PATH}/app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 로그 파일의 이름 형식 -->
+            <fileNamePattern>${LOG_FILE_PATH}/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 보관할 최대 파일 개수 -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} [%thread] %highlight(%-5level){TRACE=blue,DEBUG=green,INFO=cyan,WARN=yellow,ERROR=red} %clr(%logger{36}){magenta} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 특정 패키지의 로그 레벨 설정 -->
+    <logger name="org.apache.coyote.http11" level="INFO" />
+    <logger name="org.apache.tomcat.util.net" level="INFO" />
+    <logger name="org.apache.tomcat" level="INFO" />
+
+    <!-- 루트 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="console" />
+        <appender-ref ref="file" />
+    </root>
+
+</configuration>

--- a/src/test/java/firstskin/firstskin/dianosis/api/controller/CosmeticControllerTest.java
+++ b/src/test/java/firstskin/firstskin/dianosis/api/controller/CosmeticControllerTest.java
@@ -5,6 +5,8 @@ import firstskin.firstskin.dianosis.domain.Diagnosis;
 import firstskin.firstskin.member.domain.Member;
 import firstskin.firstskin.member.domain.Role;
 import firstskin.firstskin.member.repository.MemberRepository;
+import firstskin.firstskin.review.domain.Review;
+import firstskin.firstskin.review.repository.ReviewRepository;
 import firstskin.firstskin.skin.Kind;
 import firstskin.firstskin.skin.Skin;
 import firstskin.firstskin.skin.repository.SkinRepository;
@@ -37,6 +39,9 @@ class CosmeticControllerTest {
     @Autowired
     private DiagnosisRepository diagnosisRepository;
 
+    @Autowired
+    private ReviewRepository reviewRepository;
+
     @Test
     @DisplayName("개인별 화장품 검색 테슽트")
     @Transactional
@@ -58,8 +63,11 @@ class CosmeticControllerTest {
                 .build();
         Diagnosis saveDiagnosis = diagnosisRepository.save(build);
 
+        Review 좋아용 = new Review(savedMember, 82730935242L, "좋아용", 4, true);
+        Review 좋아용1 = new Review(savedMember, 82730935242L, "좋아용", 3, true);
 
-
+        reviewRepository.save(좋아용);
+        reviewRepository.save(좋아용1);
         //when
 
         //then

--- a/src/test/java/firstskin/firstskin/dianosis/api/controller/CosmeticControllerTest.java
+++ b/src/test/java/firstskin/firstskin/dianosis/api/controller/CosmeticControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
+import static firstskin.firstskin.skin.Kind.PERSONAL_COLOR;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -87,6 +88,22 @@ class CosmeticControllerTest {
                         .param("page", "1")
                         .param("query", "지성")
                         .param("kind", "TYPE"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("화장품 검색 퍼컬")
+    public void searchCosmetic퍼컬() throws Exception{
+        //given
+
+        //expected
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/cosmetics")
+                        .param("size", "10")
+                        .param("sort", "asc")
+                        .param("category", "립/틴트")
+                        .param("page", "1")
+                        .param("query", "봄 웜톤")
+                        .param("kind", PERSONAL_COLOR.name()))
                 .andDo(MockMvcResultHandlers.print());
     }
 


### PR DESCRIPTION
## 화장품 검색 시 평점 추가
- 화장품 목록에서 score 추가
- 리뷰에서 productId를 기준으로 각각의 리뷰의 별점을 평균내서 구함
## 개인별 진단 결과 api 구현
- 개인별 화장품 검색을 위해 멤버 각각 trouble, personalcolor, type 진단의 최근 결과를 반환
## refactoring
- 경로 상수로 관리
## logback 추가
- logback으로 로그 설정하여 로그 파일 계속 남기도록 함
- 30일 유지하며 매일 자정 날짜 별로 파일 분리
- application dev에 log 파일 경로 아래와 같이 추가해주세요(본인 로컬에 맞게)
```
logging:
  file:
    path: /Users/wonu/study/2024-1/logs```